### PR TITLE
remove call to setPlane

### DIFF
--- a/src/ofxInterfaceKeyboard.cpp
+++ b/src/ofxInterfaceKeyboard.cpp
@@ -114,7 +114,6 @@ void ofxInterfaceKeyboard::loadConfig(const string & path){
 			KeyboardButton * k = new KeyboardButton();
 			k->setPosition(x,y);
 			k->setSize(w,h);
-			k->setPlane(1);
 			addChild(k);
 
 			if((*itr)["chars"].isObject()){ //this is a "normal" key


### PR DESCRIPTION
This call is unnecessary and creates some layering problems when integrating with a the rest of the scene.